### PR TITLE
Add Link to Source Code on GitHub for Quick Access

### DIFF
--- a/index.html
+++ b/index.html
@@ -105,12 +105,12 @@
                 </a>
               </span>
               <span class="link-block">
-                <a href=""
+                <a href="https://github.com/ds-fusion/ds-fusion.github.io"
                    class="external-link button is-normal is-rounded is-dark">
                   <span class="icon">
                       <i class="fab fa-github"></i>
                   </span>
-                  <span>Code (coming soon) </span>
+                  <span>Source Code</span>
                   </a>
               </span>
               <!-- Video Link. -->


### PR DESCRIPTION
I have added a link to the source code of the webpage on GitHub for easy access by contributors. Having the source code visible on GitHub provides numerous advantages such as allowing others to review the code, contribute to it, and suggest improvements. This enhances collaboration and promotes an open-source culture where people can learn from one another.

By making the source code accessible on GitHub, it is easier for contributors to contribute to the project. This is because they can easily access the code, make changes and submit pull requests. This speeds up the development process and allows the project to be improved in a shorter amount of time. Additionally, having the source code on GitHub provides transparency and accountability, as it allows contributors to see who made what changes and when.

Overall, adding a link to the source code of the webpage on GitHub is a great way to improve collaboration, transparency, and accountability. I hope that this pull request will be accepted and that the link will be merged into the repository for everyone's benefit.